### PR TITLE
Fix SLP offsets for ECB data when using Slippi FM 3.0.3.

### DIFF
--- a/melee/console.py
+++ b/melee/console.py
@@ -763,12 +763,12 @@ class Console:
         ecb_top_x = 0
         ecb_top_y = 0
         try:
-            ecb_top_x = np.ndarray((1,), ">f", event_bytes, 0x51)[0]
+            ecb_top_x = -1 * np.ndarray((1,), ">f", event_bytes, 0x4D)[0]
         except TypeError:
             ecb_top_x = 0
         # ECB Top edge, y
         try:
-            ecb_top_y = np.ndarray((1,), ">f", event_bytes, 0x55)[0]
+            ecb_top_y = np.ndarray((1,), ">f", event_bytes, 0x51)[0]
         except TypeError:
             ecb_top_y = 0
         playerstate.ecb.top.x = ecb_top_x
@@ -779,12 +779,12 @@ class Console:
         ecb_bot_x = 0
         ecb_bot_y = 0
         try:
-            ecb_bot_x = np.ndarray((1,), ">f", event_bytes, 0x59)[0]
+            ecb_bot_x = -1 * np.ndarray((1,), ">f", event_bytes, 0x55)[0]
         except TypeError:
             ecb_bot_x = 0
         # ECB Bottom edge, y coord
         try:
-            ecb_bot_y = np.ndarray((1,), ">f", event_bytes, 0x5D)[0]
+            ecb_bot_y = np.ndarray((1,), ">f", event_bytes, 0x59)[0]
         except TypeError:
             ecb_bot_y = 0
         playerstate.ecb.bottom.x = ecb_bot_x
@@ -795,12 +795,12 @@ class Console:
         ecb_left_x = 0
         ecb_left_y = 0
         try:
-            ecb_left_x = np.ndarray((1,), ">f", event_bytes, 0x61)[0]
+            ecb_left_x = -1 * np.ndarray((1,), ">f", event_bytes, 0x5D)[0]
         except TypeError:
             ecb_left_x = 0
         # ECB left edge, y coord
         try:
-            ecb_left_y = np.ndarray((1,), ">f", event_bytes, 0x65)[0]
+            ecb_left_y = np.ndarray((1,), ">f", event_bytes, 0x61)[0]
         except TypeError:
             ecb_left_y = 0
         playerstate.ecb.left.x = ecb_left_x
@@ -811,12 +811,12 @@ class Console:
         ecb_right_x = 0
         ecb_right_y = 0
         try:
-            ecb_right_x = np.ndarray((1,), ">f", event_bytes, 0x69)[0]
+            ecb_right_x = -1 * np.ndarray((1,), ">f", event_bytes, 0x65)[0]
         except TypeError:
             ecb_right_x = 0
         # ECB right edge, y coord
         try:
-            ecb_right_y = np.ndarray((1,), ">f", event_bytes, 0x6D)[0]
+            ecb_right_y = np.ndarray((1,), ">f", event_bytes, 0x69)[0]
         except TypeError:
             ecb_right_y = 0
         playerstate.ecb.right.x = ecb_right_x


### PR DESCRIPTION
Slippi FM version: 3.0.3 (current at time of pull request)
Platform: Windows 10

When I use `smashbot_state.ecb.X.X`, I am getting incorrect values. This pull request fixes the values.

Reference: ECB data for frame 1 of Ganondorf's Dark Dive (action `SWORD_DANCE_3_LOW`). 

Note 1: these values changed slightly depending on how far away from the center of the stage I was, probably due to rounding differences at higher values. I decided for the before/after to zero out the rounding differences.

Note 2: I multiplied all x-values by -1, including top and bottom even though those are always zero. When Python 3 multiplies the floating point 0.0 by -1, it returns -0.0. Feel free to suggest/implement a fix for this if would cause issues.

Before fix:
```
Top:    (13.43673,  0.0)
Bottom: ( 3.00536,  3.65859)
Left:   ( 8.22105, -6.82228)
Right:  ( 8.22105,  0.007812503) // note: y-value is data not from the ecb
```

After fix:
```
Top:    (-0.0,    13.43673)
Bottom: (-0.0,     3.00536)
Left:   (-3.65859, 8.22105)
Right:  ( 6.82228, 8.22105)
```