### PR TITLE
Only set port to human if not a cpu

### DIFF
--- a/melee/menuhelper.py
+++ b/melee/menuhelper.py
@@ -287,7 +287,7 @@ class MenuHelper():
             return
 
         # Make sure the port is set to "Human"
-        if gamestate.players[controlling_port].controller_status != enums.ControllerStatus.CONTROLLER_HUMAN:
+        if gamestate.players[controlling_port].controller_status != enums.ControllerStatus.CONTROLLER_HUMAN and cpu_level == 0:
             MenuHelper.change_controller_status(controller, gamestate, controlling_port, enums.ControllerStatus.CONTROLLER_HUMAN)
             return
 


### PR DESCRIPTION
As is, when setting up a cpu the choose_character function will rapidly switch from human to cpu. This causes the auto start feature to not work properly.